### PR TITLE
Make parsing threadsafe

### DIFF
--- a/lib/sequel/extensions/postgis_georuby.rb
+++ b/lib/sequel/extensions/postgis_georuby.rb
@@ -5,9 +5,18 @@ module Sequel
 
       def self.extended(db)
         db.instance_exec do
-          factory = ::GeoRuby::SimpleFeatures::GeometryFactory::new
-          hex_ewkb_parser = ::GeoRuby::SimpleFeatures::HexEWKBParser.new(factory)
-          georuby_conversion_proc = lambda{|v| hex_ewkb_parser.parse(v);factory.geometry}
+          # @aryk - Allow this to work in multi-threaded environment by using a threadlocal variable to store the parser.
+          georuby_conversion_proc = lambda do |v|
+            obj = Thread.current[:sequel_postgis_geo_ruby] ||= begin
+              factory = ::GeoRuby::SimpleFeatures::GeometryFactory::new
+              {
+                :factory => factory,
+                :hex_ewkb_parser => ::GeoRuby::SimpleFeatures::HexEWKBParser.new(factory),
+              }
+            end
+            obj.fetch(:hex_ewkb_parser).parse(v)
+            obj.fetch(:factory).geometry
+          end
 
           ['geometry', 'geography'].each do |geom_type|
             add_named_conversion_proc(geom_type, &georuby_conversion_proc)

--- a/sequel-postgis-georuby.gemspec
+++ b/sequel-postgis-georuby.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = "A gem to convert Postgis geometry columns to GeoRuby Simple Features in Sequel."
   s.authors     = ["Barry Sears"]
   s.email       = 'barry.sears@gmail.com'
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '> 2.0'
   s.add_dependency 'sequel', '~> 5.0'
   s.add_dependency 'georuby', '~> 2.5.2'
 


### PR DESCRIPTION
I finally got a chance to look into why my test cases  on rails (running with threads) kept failing with bogus intermittent issues.

At first I thought the georuby library wasn't threadsafe, than I looked at the implementation and realize we keep reusing the `factory` variable.

My testcases can now run in peace 🙏 

Here is an example of some of the errors I'd get in my specs just randomly, but only when running with threads:

```ruby
GeoRuby::SimpleFeatures::EWKBFormatError: Truncated data
    app/models/network.rb:599:in `block (2 levels) in add_users'
    app/models/network.rb:575:in `each'
    app/models/network.rb:575:in `block in add_users'
    app/models/network.rb:571:in `add_users'
    test/models/network_test.rb:880:in `block in <class:NetworkTest>'
    lib/minitest-environment/lib/minitest-environment/sequel/database.rb:33:in `block (2 levels) in prepare_minitest'
    lib/minitest-environment/lib/minitest-environment/sequel/database.rb:32:in `block in prepare_minitest'
```